### PR TITLE
Return Ethernet MAC not Bluetooth Ethernet

### DIFF
--- a/Media Access Control/4DPlugin.cpp
+++ b/Media Access Control/4DPlugin.cpp
@@ -195,7 +195,7 @@ void Get_hardware_address(sLONG_PTR *pResult, PackagePtr pParams)
 				physicalAddress = CUTF8String((const uint8_t *)macAddress, 17);
 				
 				if((pCurrAddresses->IfType == IF_TYPE_ETHERNET_CSMACD)
-					 && (description.find((const PA_Unichar *)L"Bluetooth" ) != CUTF16String::npos))
+					 && (description.find((const PA_Unichar *)L"Bluetooth" ) == CUTF16String::npos))
 				{
 					returnValue.setUTF8String(&physicalAddress);
 				}


### PR DESCRIPTION
This should fix an issue where the MAC address wasn't returning from the default Ethernet adapter on Win32 an Win64.

The following is only true if the network interface contains Bluetooth in pCurrAddresses->Description
`(description.find((const PA_Unichar *)L"Bluetooth" ) != CUTF16String::npos)) `

Changed to == because find returns npos when the string is not found:
`(description.find((const PA_Unichar *)L"Bluetooth" ) != CUTF16String::npos)) `

Ignore if I'm wrong???